### PR TITLE
Fix when a user doesn't send the contact key for others

### DIFF
--- a/src/components/Contacts/ContactList.tsx
+++ b/src/components/Contacts/ContactList.tsx
@@ -97,7 +97,7 @@ function grouper(data) {
   // takes "alias"
   const ret = []
   const groups = data.reduce((r, e) => {
-    let title = e.alias[0]
+    let title = e.alias && e.alias[0]
     if (!r[title]) r[title] = { title, data: [e] }
     else r[title].data.push(e)
     return r

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -61,13 +61,16 @@ export default function Main() {
     // private key has been made
     if (priv) {
       // set into user.contactKey
-      if (me && me.contact_key) {
-        if (!user.contactKey) {
-          user.setContactKey(me.contact_key)
-        }
-
+      if (me?.contact_key && !user.contactKey) {
+        user.setContactKey(me.contact_key)
+        contacts.updateContact(user.myid, {
+          contact_key: me.contact_key
+        })
         // set into me Contact
       } else if (user.contactKey) {
+        contacts.updateContact(user.myid, {
+          contact_key: user.contactKey
+        })
       } else {
         // need to regen :(
         const keyPair = await rsa.generateKeyPair()

--- a/src/store/msg.ts
+++ b/src/store/msg.ts
@@ -10,6 +10,7 @@ import { constants } from '../constants'
 import {
   encryptText,
   makeRemoteTextMap,
+  showToastIfContactKeyError,
   decodeSingle,
   decodeMessages,
   orgMsgsFromExisting,
@@ -331,6 +332,7 @@ class MsgStore {
         if (amount) detailsStore.addToBalance(amount * -1)
       }
     } catch (e) {
+      showToastIfContactKeyError(e)
       console.log(e)
     }
   }
@@ -372,6 +374,7 @@ class MsgStore {
       if (!r) return
       this.gotNewMessage(r)
     } catch (e) {
+      showToastIfContactKeyError(e)
       console.log(e)
     }
   }


### PR DESCRIPTION
The main issue was that in some cases when the new user added as a new contact doesn't send the contact_key correctly to others, it will enter the for loop on line 58 without a value and will pass to the encryption function that couldn't handle correctly and will throw an error that is not possible to catch with a try-catch logic.

![image](https://user-images.githubusercontent.com/36285126/128712958-35c1ecaa-9438-4cff-a29c-67e67648ead8.png)

To fix this error we added a validation to prevent this to happen and inform the user about this information that is missing and we need to await the other user to send it for us. This information now will be sent to other users every time they open the app, so everyone in the app will be in sync with this important information that is needed for most of the functionalities on the app.
