### PR TITLE
Upgrade TypeScript, add typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "react-app-rewired build",
     "jetify": "jetify",
     "xcode": "open ios/Chat.xcworkspace",
-    "bump": "npx react-native bump-version --skip-semver-for android --skip-code-for android"
+    "bump": "npx react-native bump-version --skip-semver-for android --skip-code-for android",
+    "t": "tsc"
   },
   "build": {
     "appId": "Zion.chat",

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "react-native-cli-bump-version": "^1.3.0",
     "react-native-svg-transformer": "^0.14.3",
     "react-test-renderer": "16.13.1",
-    "typescript": "~3.6.3"
+    "typescript": "4.4.2"
   },
   "private": true,
   "react-native": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19061,10 +19061,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~3.6.3:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
-  integrity sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==
+typescript@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
This bumps TypeScript from v3 to the latest version, v4.4.2, enabling more informative type-checking errors. 

You can now easily typecheck by running `yarn t`. This should help with debugging going forward.

Before upgrading, `yarn t` shows 280+ nonsense errors. After upgrading, it shows 4 real errors. 

Before:

![v3](https://user-images.githubusercontent.com/14167547/131523807-d8b34fca-36d9-4ff3-944e-b8a43d1a4346.png)

After:

![typescript](https://user-images.githubusercontent.com/14167547/131523658-61898dc0-4ac5-477b-a3ff-4af14507e6c7.png)